### PR TITLE
Recreate security rules (ACL) when "clearing" GeoServer workspace

### DIFF
--- a/geocatbridge/servers/models/geoserver.py
+++ b/geocatbridge/servers/models/geoserver.py
@@ -1073,7 +1073,7 @@ class GeoserverServer(DataCatalogServerBase):
             existing_acl_rules = self.request(url).json()
             for resource, roles in existing_acl_rules.items():
                 # workspace specific rules start with "workspacename." in the resource identifier, e.g. "ws.layer1.w"
-                if resource.startswith(self.workspace):
+                if resource.startswith(f"{self.workspace}."):
                     self.logWarning(f"Found rule for {self.workspace}: {resource} -> {roles}")
                     acl_rules[resource] = roles
 

--- a/geocatbridge/servers/models/geoserver.py
+++ b/geocatbridge/servers/models/geoserver.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import List, Iterable, Dict, Union
+from typing import List, Iterable, Dict, Union, Optional
 from zipfile import ZipFile
 
 import requests
@@ -1030,7 +1030,7 @@ class GeoserverServer(DataCatalogServerBase):
     def clearWorkspace(self, recreate=True) -> bool:
         """
         Clears all feature types and coverages (rasters) and their corresponding layers.
-        Leaves styles and datastore definitions intact as well as the "isolated" flag.
+        Leaves styles and datastore definitions intact as well as the "isolated" flag and ACL security rules.
         """
         if not self.workspaceExists() and recreate:
             # Nothing to delete: workspace does not exist yet (so let's create it)
@@ -1040,6 +1040,7 @@ class GeoserverServer(DataCatalogServerBase):
         # Get database datastores configuration and isolation flag
         db_stores = []
         isolated = False
+        acl_rules = {}
         if recreate:
             url = f"{self.apiUrl}/workspaces/{self.workspace}/datastores.json"
             stores = self.request(url).json()["dataStores"] or {}
@@ -1067,6 +1068,14 @@ class GeoserverServer(DataCatalogServerBase):
             url = f"{self.apiUrl}/workspaces/{self.workspace}.json"
             workspace = self.request(url).json()
             isolated = workspace.get("workspace", {}).get("isolated", False)
+            # Get security rules / ACL
+            url = f"{self.apiUrl}/security/acl/layers.json"
+            existing_acl_rules = self.request(url).json()
+            for resource, roles in existing_acl_rules.items():
+                # workspace specific rules start with "workspacename." in the resource identifier, e.g. "ws.layer1.w"
+                if resource.startswith(self.workspace):
+                    self.logWarning(f"Found rule for {self.workspace}: {resource} -> {roles}")
+                    acl_rules[resource] = roles
 
         # Delete workspace recursively
         url = f"{self.apiUrl}/workspaces/{self.workspace}.json?recurse=true"
@@ -1074,7 +1083,7 @@ class GeoserverServer(DataCatalogServerBase):
 
         if recreate:
             # Recreate the workspace
-            self._createWorkspace(isolated)
+            self._createWorkspace(isolated, acl_rules)
 
             # Add all database datastores
             for body in db_stores:
@@ -1209,11 +1218,17 @@ class GeoserverServer(DataCatalogServerBase):
                 # Bad request or style is still in use by other layers: do nothing
                 pass
 
-    def _createWorkspace(self, isolated: bool = False):
+    def _createWorkspace(self, isolated: bool = False, acl_rules: Optional[dict[str, str]] = None):
         """ Creates the workspace. """
         url = f"{self.apiUrl}/workspaces"
         ws = {"workspace": {"name": self.workspace, "isolated": isolated}}
         self.request(url, data=ws, method="post")
+        if acl_rules:
+            self._setWorkspaceACL(acl_rules)
+
+    def _setWorkspaceACL(self, acl_rules: dict[str, str]):
+        url = f"{self.apiUrl}/security/acl/layers.json"
+        self.request(url, data=acl_rules, method="post")
 
     def _ensureWorkspaceExists(self):
         if not self.workspaceExists():


### PR DESCRIPTION
A quick implementation of https://github.com/GeoCat/qgis-bridge-plugin/issues/169. I bet I missed _something_ here as well :)

Upon workspace "clearing" (actually a deletion and creation of a new workspace) this:

1. Fetches existing ACL rules, e.g.:
```
existing_acl_rules={
  '*.*.r': '*',
  'test.*.r': 'ROLE_AUTHENTICATED',
  'test.*.w': 'ROLE_AUTHENTICATED,ROLE_LDAP_123',
  'foo.*.a': 'ROLE_OTHER',
  'foo.*.w': '*'
}
```

2. Extracts those that start with the workspace name and a dot (so that "foo2" won't be matched by "foo"), e.g.:
```
acl_rules={
  'test.*.r': 'ROLE_AUTHENTICATED',
  'test.*.w': 'ROLE_AUTHENTICATED,ROLE_LDAP_123'
}
```

3. Set those rules for the just re-created workspace.